### PR TITLE
editor.wordSeparators

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,8 @@
     "[json]": {
       "editor.tabSize": 2
     },
+    "[powershell]": {
+        "editor.wordSeparators": "`~!@#%^&*()-=+[{]}\\|;:'\",.<>/?"
+    },
     "files.trimTrailingWhitespace": true
 }


### PR DESCRIPTION
Quand tu double clique sur un variable dans vscode ca prend le $ avec ;-) pratique