### PR TITLE
Add LogEvent class to manage Event message

### DIFF
--- a/src/classes/enums.ps1
+++ b/src/classes/enums.ps1
@@ -1,0 +1,12 @@
+enum LogEventLevel {
+    Critical= 5
+    Debug = 1
+    Error = 4
+    Information = 2
+    None = 6
+    Trace = 0
+    Warning = 3
+}
+
+
+

--- a/src/classes/log.ps1
+++ b/src/classes/log.ps1
@@ -34,4 +34,95 @@ Class Log {
             }
         }
     }
+
+
+    [void] WriteMessage ([LogEvent]$m){
+        If ( $this.LogPath -ne $null ) {
+
+                $m.GetLogEvent() >> $this.LogPath
+
+        }
+    }
+
 }
+
+
+
+class LogEvent {
+
+    [datetime] $Date
+    [LogEventLevel] $Level
+    [String] $Message
+    [String] $Separator
+    [String] $Source
+
+    LogEvent([LogEventLevel] $Level,[String] $Message, [String] $Source) {
+
+        $this.Date = Get-Date
+        $this.Level =$Level
+        $this.message = $Message
+        $this.source = $Source
+        $this.Separator = "`t"
+    }
+
+    LogEvent([LogEventLevel] $Level,[String] $Message, [String] $Source, [string] $char) {
+
+        $this.Date = Get-Date
+        $this.Level =$Level
+        $this.message = $Message
+        $this.source = $Source
+        $this.Separator = $char
+    }
+
+
+    LogEvent([String] $Message) {
+
+        $this.Date = Get-Date
+        $this.Level = [LogEventLevel]::Information
+        $this.message = $Message
+        $this.source = $null
+        $this.Separator = "`t"
+    }
+
+
+    [void] SetSeparator ([String]$char){
+        $this.Separator = $char
+    }
+
+    [string] GetLogEvent () {
+
+        $timestamp = Get-Date -Date $this.Date -Format o
+        $StringBuilder = [System.Text.StringBuilder]::new($timestamp)
+
+        [void]$StringBuilder.Append($this.Separator)
+        [void]$StringBuilder.Append($this.level)
+
+        if ($this.source) {
+            [void]$StringBuilder.Append($this.Separator)
+            [void]$StringBuilder.Append($this.source)
+        }
+        [void]$StringBuilder.Append($this.Separator)
+        [void]$StringBuilder.Append($this.message)
+        [void]$StringBuilder.AppendLine()
+
+        return $StringBuilder.ToString()
+    }
+
+
+
+    [System.Object] ConvertToHashtable () {
+
+        $HashtableLogEvent = @{
+                "date" = Get-Date -Date $this.Date -Format 'hh:mm:ss'
+                "Level" = $this.Level
+                "Source" = $this.source
+                "Message" = $this.message
+            }
+
+            return $HashtableLogEvent
+    }
+
+}
+
+
+


### PR DESCRIPTION
Add  the class LogEvent to manage Log messages

There are 3 constructors 

The class can convert a logEvent object can be converted to a string with a separator (the default is a tab)
it can be converted to hashtable
It uses an enum type for Log level 
