### PR TITLE
add build task to sync local forck with source

### DIFF
--- a/build/tasks.build.ps1
+++ b/build/tasks.build.ps1
@@ -162,3 +162,14 @@ task -name analyze {
         $results | Format-Table -AutoSize
     }
 }
+
+task -name SyncFork {
+    Write-Verbose "[SYNCFORK][START]"
+
+    git remote add upstream https://github.com/FrPSUG/LogManagement.git
+    git fetch upstream
+    git pull upstream master
+    git push
+
+    Write-Verbose "[SYNCFORK][END]"
+}


### PR DESCRIPTION
Add a task in file tasks.build.ps1 to automated a synchro between the local fork and the remote source

```Powershell
Build.ps1 -task SyncFork

VERBOSE: Start Build
Build SyncFork C:\Users\Laurent.Lienhard\OneDrive\Documents\01-DEV\Powershell\LogManagement\build\tasks.build.ps1
Task /SyncFork
VERBOSE: [SYNCFORK][START]
fatal: remote upstream already exists.
From https://github.com/FrPSUG/LogManagement 
 * branch            master     -> FETCH_HEAD
Already up to date.
Everything up-to-date
VERBOSE: [SYNCFORK][END]
Done /SyncFork 00:00:05.0990522
Build succeeded. 1 tasks, 0 errors, 0 warnings 00:00:05.1450506
```